### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/Middlewares/Third_Party/FreeRTOS/Source/stream_buffer.c
+++ b/Middlewares/Third_Party/FreeRTOS/Source/stream_buffer.c
@@ -254,8 +254,16 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 		this is a quirk of the implementation that means otherwise the free
 		space would be reported as one byte smaller than would be logically
 		expected. */
-		xBufferSizeBytes++;
-		pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) ); /*lint !e9079 malloc() only returns void*. */
+		if( xBufferSizeBytes < ( xBufferSizeBytes + 1 + sizeof( StreamBuffer_t ) ) )
+        {
+            xBufferSizeBytes++;
+            pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) ); /*lint !e9079 malloc() only returns void*. */
+        }
+        else
+        {
+            pucAllocatedMemory = NULL;
+        }
+
 
 		if( pucAllocatedMemory != NULL )
 		{

--- a/lvgl/src/extra/libs/gif/gifdec.c
+++ b/lvgl/src/extra/libs/gif/gifdec.c
@@ -430,7 +430,7 @@ read_image_data(gd_GIF *gif, int interlace)
             if (interlace)
                 y = interlaced_line_index((int) gif->fh, y);
             gif->frame[(gif->fy + y) * gif->width + gif->fx + x] = entry.suffix;
-            if (entry.prefix == 0xFFF)
+            if (entry.prefix == 0xFFF || entry.prefix >= table->nentries)
                 break;
             else
                 entry = table->entries[entry.prefix];


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `xStreamBufferGenericCreate` that was cloned from https://github.com/FreeRTOS/FreeRTOS-Kernel but did not receive the security patch.

### Details:
Affected Function: `xStreamBufferGenericCreate` in `Middlewares/Third_Party/FreeRTOS/Source/stream_buffer.c`
Original Fix: https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/d05b9c123f2bf9090bce386a244fc934ae44db5b


### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/d05b9c123f2bf9090bce386a244fc934ae44db5b
- CVE-2021-31572: https://nvd.nist.gov/vuln/detail/CVE-2021-31572
- https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/226

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
